### PR TITLE
Ignore oit layout if webgl.

### DIFF
--- a/crates/bevy_pbr/src/render/mesh_view_bindings.rs
+++ b/crates/bevy_pbr/src/render/mesh_view_bindings.rs
@@ -358,7 +358,7 @@ fn layout_entries(
     ));
 
     // OIT
-    if layout_key.contains(MeshPipelineViewLayoutKey::OIT_ENABLED) {
+    if cfg!(not(feature = "webgl")) && layout_key.contains(MeshPipelineViewLayoutKey::OIT_ENABLED) {
         entries = entries.extend_with_indices((
             // oit_layers
             (31, storage_buffer_sized(false, None)),


### PR DESCRIPTION
Conditionally removing the key itself would be pretty disruptive. Theoretically the user could still add the settings to their camera and nothing would happen.